### PR TITLE
fix: allow sysctl value to be provided as int

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,14 +31,14 @@
 #   Enforce configured value during each run (can't work with custom files).
 #
 define sysctl (
-  Enum['present', 'absent']           $ensure  = 'present',
-  Optional[String[1]]                 $value   = undef,
-  Optional[String[1]]                 $prefix  = undef,
-  String                              $suffix  = '.conf',
-  Optional[Variant[Array, String[1]]] $comment = undef,
-  Optional[String[1]]                 $content = undef,
-  Optional[Stdlib::Filesource]        $source  = undef,
-  Boolean                             $enforce = true,
+  Enum['present', 'absent']             $ensure  = 'present',
+  Optional[Variant[Integer, String[1]]] $value   = undef,
+  Optional[String[1]]                   $prefix  = undef,
+  String                                $suffix  = '.conf',
+  Optional[Variant[Array, String[1]]]   $comment = undef,
+  Optional[String[1]]                   $content = undef,
+  Optional[Stdlib::Filesource]          $source  = undef,
+  Boolean                               $enforce = true,
 ) {
   include sysctl::base
 

--- a/spec/defines/init_spec.rb
+++ b/spec/defines/init_spec.rb
@@ -123,6 +123,13 @@ describe 'sysctl', type: :define do
         end
       end
 
+      context 'with value set to int 1' do
+        let(:params) { { value: 1 } }
+
+        it { is_expected.to compile }
+        it { is_expected.to contain_file('/etc/sysctl.d/net.ipv4.ip_forward.conf').with_content(header + "net.ipv4.ip_forward = 1\n") }
+      end
+
       context 'with prefix set to valid .testing' do
         let(:params) do
           {

--- a/templates/sysctl.d-file.epp
+++ b/templates/sysctl.d-file.epp
@@ -1,6 +1,6 @@
-<%- | Optional[Variant[Array, String[1]]] $comment,
-      String                              $key_name,
-      Optional[String[1]]                 $key_val,
+<%- | Optional[Variant[Array, String[1]]]   $comment,
+      String                                $key_name,
+      Optional[Variant[Integer, String[1]]] $key_val,
 | -%>
 # This file is being maintained by Puppet.
 # DO NOT EDIT


### PR DESCRIPTION
Hello,
the systctl define expects the value to be of type string, while in fact many times the "real" data type of sysctl values is integer. While this is not problematic by itself, it comes in unhandy when providing the values via Hiera as they always must be quoted.
This PR fixes this by changing the type of the value parameter to be a variant of integer and string.

Best regards,
Sven