### PR TITLE
Sedfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#### 2025-01-06 - 1.0.10
+* Moved away from using an absolute path to expand compatibility across OS versions
+
 #### 2024-12-02 - 1.0.9
 * Updated metadata
 * Merged schustersv PR allowing sysctl::value to include Integer types

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 #### 2025-01-06 - 1.0.10
 * Moved away from using an absolute path to expand compatibility across OS versions
+* Fixed issue comparing tabbed and non-tabbed data in the resource declaration
 
 #### 2024-12-02 - 1.0.9
 * Updated metadata

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -101,8 +101,7 @@ define sysctl (
       # Value may contain '|' and others, we need to quote to be safe
       # Convert any numerical to expected string, 0 instead of '0' would fail
       # lint:ignore:only_variable_string Convert numerical to string
-      $qvalue = shellquote("${value}")
-      # lint:endignore
+      $qvalue = shellquote("${value}").regsubst("[ |\t]+", " ", 'G')      # lint:endignore
       exec { "enforce-sysctl-value-${qtitle}":
         unless  => "/usr/bin/test \"$(/sbin/sysctl -n ${qtitle} | sed -r -e 's/[ \t]+/ /g')\" = ${qvalue}",
         command => "/sbin/sysctl -w ${qtitle}=${qvalue}",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -104,7 +104,7 @@ define sysctl (
       $qvalue = shellquote("${value}")
       # lint:endignore
       exec { "enforce-sysctl-value-${qtitle}":
-        unless  => "/usr/bin/test \"$(/sbin/sysctl -n ${qtitle} | /usr/bin/sed -r -e 's/[ \t]+/ /g')\" = ${qvalue}",
+        unless  => "/usr/bin/test \"$(/sbin/sysctl -n ${qtitle} | sed -r -e 's/[ \t]+/ /g')\" = ${qvalue}",
         command => "/sbin/sysctl -w ${qtitle}=${qvalue}",
       }
     }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "purplejac-sysctl",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "author": "Ras",
   "summary": "Sysctl module",
   "license": "Apache-2.0",


### PR DESCRIPTION
* Moved away from using an absolute path to expand compatibility across OS versions
* Fixed issue comparing tabbed and non-tabbed data in the resource declaration
